### PR TITLE
Chore: setup a store with zustand + immer

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "expo-font": "~11.4.0",
     "expo-splash-screen": "~0.20.5",
     "expo-status-bar": "~1.6.0",
+    "immer": "^10.0.3",
     "react": "18.2.0",
     "react-native": "0.72.5",
     "react-native-paper": "^5.10.6",
-    "react-native-safe-area-context": "4.6.3"
+    "react-native-safe-area-context": "4.6.3",
+    "zustand": "^4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -1,10 +1,14 @@
-import { View } from "react-native";
-import { Text } from "react-native-paper";
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useStore } from 'src/store/store';
 
 export function HelloWorld() {
+  const store = useStore();
+
   return (
     <View>
-      <Text variant="displayLarge">Hello World!</Text>
+      <Text variant='displayLarge'>Hello World!</Text>
+      <Text>Have you considered calling yourself "{store.user.name}"?</Text>
     </View>
   );
 }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: string;
+  name: string;
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { User } from 'src/models/user';
+
+//State represent the content of the store
+type State = {
+  user: User;
+};
+
+// Actions represent the available function to modify the store
+type Actions = {
+  setUser: (user: User) => void;
+};
+
+// Create a store instance, wrapped with immer
+export const useStore = create(
+  immer<State & Actions>((set) => ({
+    user: {
+      id: '0000-0000-0000-0000',
+      name: 'dummy',
+    },
+
+    // Assign the user
+    setUser: (user) =>
+      set((state) => {
+        state.user = user;
+      }),
+  }))
+);


### PR DESCRIPTION
Turns out it doesn't need a provider.
Zustand was used for its more straightforward approach while keeping immer to have the ability to perform "mutable" state changes